### PR TITLE
Add missing <cstdint> includes

### DIFF
--- a/src/Engine/ConsoleVariableEnum.h
+++ b/src/Engine/ConsoleVariableEnum.h
@@ -15,6 +15,7 @@
 #pragma once
 
 #include <vector>
+#include <cstdint>
 #include "ConsoleVariable.h"
 
 class ConsoleVariableEnum : public ConsoleVariable

--- a/src/Engine/HelpPages.h
+++ b/src/Engine/HelpPages.h
@@ -20,6 +20,7 @@
 //
 #pragma once
 
+#include <cstdint>
 #include <string>
 #include <vector>
 


### PR DESCRIPTION
Did not compile for me with gcc version 13.2.1 20230801 (GCC) (Arch linux btw) until I added <cstdint> in these two header files.
