### PR TITLE
Fix build with GCC15 and Woa64

### DIFF
--- a/ThirdParty/ReflectionHLE/backend/audio/be_audio_mixer.c
+++ b/ThirdParty/ReflectionHLE/backend/audio/be_audio_mixer.c
@@ -34,6 +34,7 @@
 #include <assert.h>
 #include <stdlib.h>
 #include <string.h>
+#include <math.h>
 
 /* These tables are based on dB values described here by James-F:
    https://www.vogons.org/viewtopic.php?t=54269 */

--- a/ThirdParty/ReflectionHLE/backend/cfg/be_cfg.c
+++ b/ThirdParty/ReflectionHLE/backend/cfg/be_cfg.c
@@ -28,6 +28,7 @@
 
 #include <limits.h>
 #include <string.h>
+#include <stdlib.h>
 
 #include "../audio/be_audio_private.h"
 //#include "../input/be_input_tables.h"

--- a/src/Engine/ConsoleVariableInt.h
+++ b/src/Engine/ConsoleVariableInt.h
@@ -15,6 +15,7 @@
 #pragma once
 
 #include "ConsoleVariable.h"
+#include <cstdint>
 
 class ConsoleVariableInt : public ConsoleVariable
 {

--- a/src/System/CatacombGL.cpp
+++ b/src/System/CatacombGL.cpp
@@ -52,6 +52,7 @@ extern "C" {
 #include <SDL_video.h>
 #include <cstdint>
 #include <cstdio>
+#include <cstring>
 #include <filesystem>
 #include <iostream>
 

--- a/src/System/RendererOpenGL.cpp
+++ b/src/System/RendererOpenGL.cpp
@@ -39,6 +39,7 @@ static const unsigned int GL_CLAMP_TO_EDGE = 0x812F;
 #endif
 #include <SDL_video.h>
 #include <cmath>
+#include <cstring>
 #include <string>
 
 const float FloorZ = 2.2f;


### PR DESCRIPTION
GCC15 introduced support  for Windows on ARM64 (Woa64) as new platform.
So, I tried the engine with `aarch64-w64-mingw32` cross compiler but I got these errors:

```
ThirdParty/ReflectionHLE/backend/cfg/be_cfg.c: In function ‘BEL_ST_ParseHexInt’:
ThirdParty/ReflectionHLE/backend/cfg/be_cfg.c:378:20: error: implicit declaration of function ‘strtol’; did you mean ‘strtok’? [-Wimplicit-function-declaration]
  378 |         long ret = strtol(buffer, 0, 16);
      |                    ^~~~~~
      |                    strtok
ThirdParty/ReflectionHLE/backend/cfg/be_cfg.c: In function ‘BEL_ST_ParseInt’:
ThirdParty/ReflectionHLE/backend/cfg/be_cfg.c:390:19: error: implicit declaration of function ‘atoi’ [-Wimplicit-function-declaration]
  390 |         int ret = atoi(buffer);
      |                   ^~~~
```

```
ThirdParty/ReflectionHLE/backend/audio/be_audio_mixer.c: In function ‘BEL_ST_AudioMixerAddSource’:
ThirdParty/ReflectionHLE/backend/audio/be_audio_mixer.c:174:30: error: implicit declaration of function ‘exp’ [-Wimplicit-function-declaration]
  174 |                        0.0 : exp((userVolAsInt - BE_AUDIO_VOL_MAX)/4.0);
      |                              ^~~
ThirdParty/ReflectionHLE/backend/audio/be_audio_mixer.c:37:1: note: include ‘<math.h>’ or provide a declaration of ‘exp’
   36 | #include <string.h>
  +++ |+#include <math.h>
   37 |
```

```
In file included from src/Engine/ConsoleVariableInt.cpp:16:
src/Engine/ConsoleVariableInt.h:25:15: error: ‘int32_t’ does not name a type
   25 |         const int32_t minValue,
      |               ^~~~~~~
src/Engine/ConsoleVariableInt.h:18:1: note: ‘int32_t’ is defined in header ‘<cstdint>’; this is probably fixable by adding ‘#include <cstdint>’
   17 | #include "ConsoleVariable.h"
  +++ |+#include <cstdint>
   18 |
```

```
src/System/CatacombGL.cpp: In function ‘void InitializeSDL()’:
src/System/CatacombGL.cpp:99:9: error: ‘memset’ was not declared in this scope
   99 |         memset(&sdlVersion, 0, sizeof(sdlVersion));
      |         ^~~~~~
src/System/CatacombGL.cpp:57:1: note: ‘memset’ is defined in header ‘<cstring>’; did you forget to ‘#include <cstring>’?
   56 | #include <iostream>
  +++ |+#include <cstring>
   57 |
```

```
src/System/RendererOpenGL.cpp: In constructor ‘RendererOpenGL::RendererOpenGL()’:
src/System/RendererOpenGL.cpp:61:5: error: ‘memset’ was not declared in this scope
   61 |     memset(&m_singleColorTexture, 0, sizeof(m_singleColorTexture[0]) * EgaRange);
      |     ^~~~~~
src/System/RendererOpenGL.cpp:42:1: note: ‘memset’ is defined in header ‘<cstring>’; did you forget to ‘#include <cstring>’?
   41 | #include <cmath>
  +++ |+#include <cstring>
   42 | #include <string>
```

Attached patch applies few tiny fixes and now it is possible to build CatacombGL for running natively on Woa64.
